### PR TITLE
Fix 'TypeError: options argument must be an object' error due to spawn() changes

### DIFF
--- a/lib/node-speakable.js
+++ b/lib/node-speakable.js
@@ -72,7 +72,7 @@ Speakable.prototype.postVoiceData = function() {
 Speakable.prototype.recordVoice = function() {
   var self = this;
 
-  var rec = spawn(self.cmd, self.cmdArgs, 'pipe');
+  var rec = spawn(self.cmd, self.cmdArgs, {stdin: 'pipe'});
 
   // Process stdout
 


### PR DESCRIPTION
This small change fixes #13 and fixes #15 (which is a dupe). I've tested on node/0.12.7 and node/5.7.0 and it seems to work on both.
